### PR TITLE
Feat/pagina busca voos

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import * as React from "react"
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react"
+import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+}) {
+  const defaultClassNames = getDefaultClassNames()
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString("default", { month: "short" }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+          "flex gap-4 flex-col md:flex-row relative",
+          defaultClassNames.months
+        ),
+        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        nav: cn(
+          "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
+          defaultClassNames.nav
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_previous
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_next
+        ),
+        month_caption: cn(
+          "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
+          defaultClassNames.month_caption
+        ),
+        dropdowns: cn(
+          "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
+          defaultClassNames.dropdowns
+        ),
+        dropdown_root: cn(
+          "relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md",
+          defaultClassNames.dropdown_root
+        ),
+        dropdown: cn("absolute inset-0 opacity-0", defaultClassNames.dropdown),
+        caption_label: cn(
+          "select-none font-medium",
+          captionLayout === "label"
+            ? "text-sm"
+            : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
+          defaultClassNames.caption_label
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",
+          defaultClassNames.weekday
+        ),
+        week: cn("flex w-full mt-2", defaultClassNames.week),
+        week_number_header: cn(
+          "select-none w-(--cell-size)",
+          defaultClassNames.week_number_header
+        ),
+        week_number: cn(
+          "text-[0.8rem] select-none text-muted-foreground",
+          defaultClassNames.week_number
+        ),
+        day: cn(
+          "relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+          defaultClassNames.day
+        ),
+        range_start: cn(
+          "rounded-l-md bg-accent",
+          defaultClassNames.range_start
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        today: cn(
+          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
+          defaultClassNames.today
+        ),
+        outside: cn(
+          "text-muted-foreground aria-selected:text-muted-foreground",
+          defaultClassNames.outside
+        ),
+        disabled: cn(
+          "text-muted-foreground opacity-50",
+          defaultClassNames.disabled
+        ),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          )
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === "left") {
+            return (
+              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+            )
+          }
+
+          if (orientation === "right") {
+            return (
+              <ChevronRightIcon
+                className={cn("size-4", className)}
+                {...props}
+              />
+            )
+          }
+
+          return (
+            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+          )
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          )
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  )
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames()
+
+  const ref = React.useRef<HTMLButtonElement>(null)
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+        defaultClassNames.day,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar, CalendarDayButton }

--- a/src/components/ui/column.ts
+++ b/src/components/ui/column.ts
@@ -1,0 +1,51 @@
+import { ColumnDef } from "@tanstack/react-table";
+
+export type Flight = {
+  flightNumber: string;
+  airline: string;
+  origin: string;
+  destination: string;
+  departure: string;
+  arrival: string;
+  price: string;
+};
+
+export const columns: ColumnDef<Flight>[] = [
+  {
+    accessorKey: "flightNumber",
+    header: "Nº do Voo",
+  },
+  {
+    accessorKey: "airline",
+    header: "Companhia",
+  },
+  {
+    accessorKey: "origin",
+    header: "Origem",
+  },
+  {
+    accessorKey: "destination",
+    header: "Destino",
+  },
+  {
+    accessorKey: "departure",
+    header: "Partida",
+    cell: ({ row }) => {
+      const date = new Date(row.original.departure);
+      return date.toLocaleString();
+    },
+  },
+  {
+    accessorKey: "arrival",
+    header: "Chegada",
+    cell: ({ row }) => {
+      const date = new Date(row.original.arrival);
+      return date.toLocaleString();
+    },
+  },
+  {
+    accessorKey: "price",
+    header: "Preço",
+    cell: ({ row }) => `R$ ${row.original.price}`,
+  },
+];

--- a/src/components/ui/custom-pagination.tsx
+++ b/src/components/ui/custom-pagination.tsx
@@ -1,0 +1,33 @@
+import { Pagination, PaginationContent, PaginationItem, PaginationPrevious, PaginationNext } from "@/components/ui/pagination";
+
+interface CustomPaginationProps {
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (newPage: number) => void;
+}
+
+export function CustomPagination({ totalPages, currentPage, onPageChange }: CustomPaginationProps) {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+            className={currentPage === 1 ? "opacity-50 pointer-events-none" : ""}
+          />
+        </PaginationItem>
+
+        <span className="px-4 text-sm text-gray-700">
+          Página {currentPage} de {totalPages}
+        </span>
+
+        <PaginationItem>
+          <PaginationNext
+            onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+            className={currentPage === totalPages ? "opacity-50 pointer-events-none" : ""}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}

--- a/src/components/ui/data-input.tsx
+++ b/src/components/ui/data-input.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { format } from "date-fns";
+import { Calendar } from "@/components/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+interface DataInputProps {
+  date?: Date;
+  setDate: (date: Date | undefined) => void;
+}
+
+export function DataInput({ date, setDate }: DataInputProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          id="date"
+          className="w-full justify-between font-normal border-gray-300"
+        >
+          {date ? format(date, "dd/MM/yyyy") : "Data de partida"}
+          <ChevronDownIcon className="ml-2 h-4 w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={date}
+          captionLayout="dropdown"
+          onSelect={(date) => {
+            setDate(date);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="rounded-lg border bg-white">
+      <Table className="w-full text-sm text-gray-700">
+        <TableHeader className="bg-gray-100">
+            {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id} className="px-4 py-3 font-semibold text-gray-800">
+                            {header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())}
+                        </TableHead>
+                    ))}
+                </TableRow>
+            ))}
+        </TableHeader>
+
+        <TableBody>
+            {table.getRowModel().rows.length ? (
+                table.getRowModel().rows.map((row, idx) => (
+                    <TableRow
+                        key={row.id}
+                        className={`hover:bg-gray-100 ${
+                            idx % 2 === 0 ? "bg-white" : "bg-gray-50"
+                        }`}
+                    >
+                        {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id} className="px-4 py-4">
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))
+            ) : (
+                <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                        Nenhum resultado.
+                    </TableCell>
+                </TableRow>
+            )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Anterior</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Próximo</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/components/ui/search-flight.tsx
+++ b/src/components/ui/search-flight.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { DataInput } from "./data-input";
+import { Input } from "./input";
+import { searchFlights, getFlights } from "@/services/flightService";
+import { format } from "date-fns";
+import { Button } from "./button";
+import { DataTable } from "./data-table";
+import { columns } from "./column";
+import { Plane } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Pagination } from "@/components/ui/pagination";
+import { CustomPagination } from "./custom-pagination";
+
+interface Flight {
+    flightNumber: string;
+    airline: string;
+    origin: string;
+    destination: string;
+    departure: string;
+    arrival: string;
+    price: string;
+}
+
+export default function SearchFlight() {
+    const [origin, setOrigin] = useState("");
+    const [destination, setDestination] = useState("");
+    const [date, setDate] = useState<Date | undefined>();
+    const [flights, setFlights] = useState<Flight[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [hasSearched, setHasSearched] = useState(false);
+    const [page, setPage] = useState(1);
+    const [totalPages, setTotalPages] = useState(1);
+
+    const pageSize = 10;
+
+    useEffect(() => {
+        if (!hasSearched) {
+            fetchFlights(page);
+        }
+    }, [page, hasSearched]);
+
+    async function fetchFlights(pageNumber: number) {
+        setLoading(true);
+        try {
+            const response = await getFlights(pageNumber, pageSize);
+            setFlights(response.data);
+            setTotalPages(Math.ceil(response.total / pageSize));
+        } catch (error) {
+            setFlights([]);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function handleSearch(event: React.FormEvent) {
+        event.preventDefault();
+        setLoading(true);
+        setHasSearched(true);
+
+        try {
+            const formattedDate = format(date!, "yyyy-MM-dd");
+            const data = await searchFlights({ origin, destination, departure: formattedDate });
+            setFlights(data);
+        } catch (error) {
+            setFlights([]);
+        } finally {
+            setLoading(false);
+        }
+    }
+    
+    return (
+        <div className="flex flex-col gap-6">
+            <form onSubmit={handleSearch} className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Input
+                    className="border border-gray-300 p-4 rounded-lg"
+                    type="text"
+                    placeholder="Origem"
+                    value={origin}
+                    onChange={(e) => setOrigin(e.target.value)}
+                />
+                <Input
+                    className="border border-gray-300 p-4 rounded-lg"
+                    type="text"
+                    placeholder="Destino"
+                    value={destination}
+                    onChange={(e) => setDestination(e.target.value)}
+                />
+                <DataInput date={date} setDate={setDate} />
+                <div className="md:col-span-3">
+                    <Button
+                        type="submit"
+                        className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg"
+                        disabled={loading}
+                    >
+                        {loading ? "Buscando..." : "Buscar voos"}
+                    </Button>
+                </div>
+            </form>
+
+            {loading && (
+                <div className="mt-8 space-y-4">
+                    {[...Array(3)].map((_, index) => (
+                        <div key={index} className="flex items-center space-x-4">
+                            <Skeleton className="h-12 w-12 rounded-full" />
+                            <div className="space-y-2 w-full">
+                                <Skeleton className="h-4 w-full" />
+                                <Skeleton className="h-4 w-1/2" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {!loading && flights.length > 0 && (
+                <div className="mt-8 flex flex-col items-center gap-4">
+                    <div className="w-full overflow-x-auto">
+                        <div className="min-w-[800px] mx-auto rounded-xl border border-gray-300 bg-gray-50 shadow-lg">
+                            <DataTable columns={columns} data={flights} />
+                        </div>
+                    </div>
+
+                    {!hasSearched && (
+                        <CustomPagination
+                            totalPages={totalPages}
+                            currentPage={page}
+                            onPageChange={(newPage) => setPage(newPage)}
+                        />
+                    )}
+                </div>
+            )}
+
+            {hasSearched && !loading && flights.length === 0 && (
+                <div className="flex flex-col items-center justify-center mt-12 text-gray-500">
+                    <Plane className="w-16 h-16 mb-4 opacity-50" />
+                    <p className="text-lg">Nenhum voo encontrado para os critérios informados.</p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const api = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001/api",
+    timeout: 10000
+});
+
+export default api;

--- a/src/services/flightService.ts
+++ b/src/services/flightService.ts
@@ -1,0 +1,29 @@
+import api from "@/lib/api";
+
+interface SearchFlightParams {
+    origin: string;
+    destination: string;
+    departure: string;
+}
+
+export async function searchFlights(params: SearchFlightParams) {
+    const { origin, destination, departure } = params;
+    const response = await api.get("/flights/search", {
+        params: {
+            origin,
+            destination,
+            departure
+        }
+    });
+    return response.data;
+}
+
+export async function getFlights(page = 1, pageSize = 10) {
+    const response = await api.get("/flights", {
+        params: {
+            page,
+            pageSize
+        }
+    });
+    return response.data;
+}


### PR DESCRIPTION
**feat: implementar página de busca de voos com tabela e paginação**

### Descrição:

Este PR entrega a primeira versão da tela de busca de voos, contendo:

* Formulário com campos de origem, destino e data de partida
* Integração com o backend para listagem paginada de voos disponíveis
* Busca por critérios específicos via `/flights/search`
* Exibição dos resultados em tabela responsiva utilizando `@tanstack/react-table`
* Feedback visual de carregamento (skeletons)
* Estado de vazio com ícone informativo caso nenhum voo seja encontrado
* Componente de paginação customizada para navegação entre páginas
* Separação dos componentes de UI em estrutura reutilizável (`DataTable`, `Input`, `Button`, `Calendar`, etc)
* Configuração inicial do Axios centralizado em `/lib/api.ts`

---
